### PR TITLE
base64EncodedSecret disabled by default

### DIFF
--- a/grails-app/conf/auth0.properties
+++ b/grails-app/conf/auth0.properties
@@ -7,7 +7,7 @@ auth0.securedRoute: /portal/*
 auth0.loginCallback: /callback
 auth0.loginRedirectOnSuccess: /portal/home
 auth0.loginRedirectOnFail: /login
-auth0.base64EncodedSecret: true
+auth0.base64EncodedSecret: false
 auth0.authorityStrategy: ROLES
 auth0.defaultAuth0WebSecurityEnabled: false
 auth0.signingAlgorithm: HS256


### PR DESCRIPTION
base64EncodedSecret is disabled by default as described in this [issue](https://github.com/auth0-samples/auth0-grails3-mvc-sample/issues/1). If set to true, the login fails to verify client-secret.